### PR TITLE
Bugfix: Avoid Casa reload plugins on each repository sync

### DIFF
--- a/scripts/jca_sync.py
+++ b/scripts/jca_sync.py
@@ -43,12 +43,11 @@ def sync_from_webdav(url, username, password):
                 if not os.path.exists(os.path.dirname(dest)):
                     os.makedirs(os.path.dirname(dest))
 
-                if os.path.exists(dest) and not filecmp.cmp(src, dest, shallow=False):
-                    # logger.info(f"Copying {src} to {dest}")
-                    shutil.copyfile(src, dest)
-                else:
-                    # logger.info(f"Copying {src} to {dest}")
-                    shutil.copyfile(src, dest)
+                if os.path.exists(dest) and filecmp.cmp(src, dest, shallow=False):
+                    continue
+
+                # logger.info(f"Copying {src} to {dest}")
+                shutil.copyfile(src, dest)
 
     except (RemoteResourceNotFound, NoConnection) as exc:
         logger.warning(f"Unable to sync files from {url}{ROOT_DIR}{SYNC_DIR}; reason={exc}")

--- a/scripts/jca_sync.py
+++ b/scripts/jca_sync.py
@@ -3,6 +3,7 @@ import logging.config
 import os
 import shutil
 import time
+import filecmp
 
 from webdav3.client import Client
 from webdav3.exceptions import RemoteResourceNotFound
@@ -41,8 +42,11 @@ def sync_from_webdav(url, username, password):
 
                 if not os.path.exists(os.path.dirname(dest)):
                     os.makedirs(os.path.dirname(dest))
-                # logger.info(f"Copying {src} to {dest}")
-                shutil.copyfile(src, dest)
+
+                if not filecmp.cmp(src, dest, shallow=False):
+                    # logger.info(f"Copying {src} to {dest}")
+                    shutil.copyfile(src, dest)
+
     except (RemoteResourceNotFound, NoConnection) as exc:
         logger.warning(f"Unable to sync files from {url}{ROOT_DIR}{SYNC_DIR}; reason={exc}")
 

--- a/scripts/jca_sync.py
+++ b/scripts/jca_sync.py
@@ -43,7 +43,10 @@ def sync_from_webdav(url, username, password):
                 if not os.path.exists(os.path.dirname(dest)):
                     os.makedirs(os.path.dirname(dest))
 
-                if not filecmp.cmp(src, dest, shallow=False):
+                if os.path.exists(dest) and not filecmp.cmp(src, dest, shallow=False):
+                    # logger.info(f"Copying {src} to {dest}")
+                    shutil.copyfile(src, dest)
+                else:
                     # logger.info(f"Copying {src} to {dest}")
                     shutil.copyfile(src, dest)
 


### PR DESCRIPTION
Casa is reloading plugins because files are updated from jackrabbit repository (timestamp)
This PR compares file contents to avoid replace files when they are identical, thus avoiding casa from restart plugins

